### PR TITLE
1862 Add repository settings and gitpod.yml; remove canonical.json

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,20 @@
+# These settings are synced to GitHub by https://probot.github.io/apps/settings/ via https://github.com/openstax/staxly
+
+repository:
+  # private: false
+
+  has_issues: false
+  has_wiki: false
+  has_projects: false
+  has_downloads: false
+
+  allow_auto_merge: true
+  delete_branch_on_merge: true
+
+teams:
+  - name: ce-admins
+    permission: push
+  - name: ce-all
+    permission: triage
+  - name: content-managers
+    permission: push

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,3 @@
+vscode:
+  extensions:
+    - openstax.editor

--- a/canonical.json
+++ b/canonical.json
@@ -1,3 +1,0 @@
-[
-  "template-slug"
-]


### PR DESCRIPTION
- [x] openstax/ce#1862

In the process of making the approved books public, we added two files to each repository: .github/settings.yml file and .gitpod.yml. This PR adds those files to the template for future use. The setting that makes the repository public has been commented out.

It also removes the canonical.json file from the template since we do not use that file anymore. 